### PR TITLE
Keep the default behaviour to apply transformRequest

### DIFF
--- a/angular-file-upload.js
+++ b/angular-file-upload.js
@@ -37,7 +37,7 @@ angularFileUpload.service('$upload', ['$http', '$rootScope', '$timeout', functio
 							});
 						}
 					}, false);
-				}	
+				};
 			};
 		}
 			
@@ -46,7 +46,7 @@ angularFileUpload.service('$upload', ['$http', '$rootScope', '$timeout', functio
 		promise.progress = function(fn) {
 			config.progress = fn;
 			return promise;
-		};		
+		};
 		promise.abort = function() {
 			if (config.__XHR) {
 				$timeout(function() {
@@ -54,7 +54,7 @@ angularFileUpload.service('$upload', ['$http', '$rootScope', '$timeout', functio
 				});
 			}
 			return promise;
-		};		
+		};
 		promise.then = (function(promise, origThen) {
 			return function(s, e, p) {
 				config.progress = p || config.progress;
@@ -66,7 +66,7 @@ angularFileUpload.service('$upload', ['$http', '$rootScope', '$timeout', functio
 		})(promise, promise.then);
 		
 		return promise;
-	};
+	}
 	this.upload = function(config) {
 		config.headers = config.headers || {};
 		config.headers['Content-Type'] = undefined;
@@ -109,9 +109,9 @@ angularFileUpload.service('$upload', ['$http', '$rootScope', '$timeout', functio
 		var fileFormName = config.fileFormDataName || 'file';
 		
 		if (Object.prototype.toString.call(config.file) === '[object Array]') {
-			var isFileFormNameString = Object.prototype.toString.call(fileFormName) === '[object String]'; 
-			for (var i = 0; i < config.file.length; i++) {										
-				formData.append(isFileFormNameString ? fileFormName + i : fileFormName[i], config.file[i], config.file[i].name);
+			var isFileFormNameString = Object.prototype.toString.call(fileFormName) === '[object String]';
+			for (var j = 0; j < config.file.length; j++) {
+				formData.append(isFileFormNameString ? fileFormName + j : fileFormName[j], config.file[j], config.file[j].name);
 			}
 		} else {
 			formData.append(fileFormName, config.file, config.file.name);
@@ -123,7 +123,7 @@ angularFileUpload.service('$upload', ['$http', '$rootScope', '$timeout', functio
 	};
 	this.http = function(config) {
 		return sendHttp(config);
-	}
+	};
 }]);
 
 angularFileUpload.directive('ngFileSelect', [ '$parse', '$http', '$timeout', function($parse, $http, $timeout) {
@@ -132,7 +132,7 @@ angularFileUpload.directive('ngFileSelect', [ '$parse', '$http', '$timeout', fun
 		elem.bind('change', function(evt) {
 			var files = [], fileList, i;
 			fileList = evt.target.files;
-			if (fileList != null) {
+			if (fileList !== null) {
 				for (i = 0; i < fileList.length; i++) {
 					files.push(fileList.item(i));
 				}
@@ -182,7 +182,7 @@ angularFileUpload.directive('ngFileDrop', [ '$parse', '$http', '$timeout', funct
 				evt.preventDefault();
 				elem.removeClass(attr['ngFileDragOverClass'] || "dragover");
 				var files = [], fileList = evt.dataTransfer.files, i;
-				if (fileList != null) {
+				if (fileList !== null) {
 					for (i = 0; i < fileList.length; i++) {
 						files.push(fileList.item(i));
 					}


### PR DESCRIPTION
Angular apply transformRequest using 3 parameters
- data: the object which contains all parameters
- headerGetter: a function which return the header value of a key or if there is no keys the header object
- transformRequest: the array of functions to pre-process your data

This code allow to restaure this behaviour and then add those processed parameters in the formData
