### PR TITLE
add angular as dependency to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,9 @@
     "danialf <danial.farid@gmail.com>"
   ],
   "description": "Lightweight Angular JS directive to upload files. Support drag&drop, progress and abort",
+  "dependencies": {
+    "angular": "^1.3.0 || >1.4.0-beta.0"
+  },
   "ignore": [],
   "license": "MIT"
  }


### PR DESCRIPTION
I had to add angular as a dependency in the bower.json to help wiredep determine the order of injection in the index file of my project. Thought that it could be useful for others as well.